### PR TITLE
WP-CLI unexpected behaviour with PHP < 7 

### DIFF
--- a/classicpress-seo.php
+++ b/classicpress-seo.php
@@ -249,7 +249,7 @@ class Classic_SEO {
 			return true;
 		}
 		
-		if ( defined( 'WP_CLI' ) && WP_CLI && (! empty( $this->messages ) ) ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI && ! ( empty( $this->messages ) ) ) {
 			return \WP_CLI::error( implode( "\n", $this->messages ) );
 		}
 

--- a/classicpress-seo.php
+++ b/classicpress-seo.php
@@ -248,6 +248,10 @@ class Classic_SEO {
 		if ( empty( $this->messages ) ) {
 			return true;
 		}
+		
+		if ( defined( 'WP_CLI' ) && WP_CLI && (! empty( $this->messages ) ) ) {
+			return \WP_CLI::error( implode( "\n", $this->messages ) );
+		}
 
 		// Auto-deactivate plugin.
 		add_action( 'admin_init', [ $this, 'auto_deactivate' ] );

--- a/classicpress-seo.php
+++ b/classicpress-seo.php
@@ -250,7 +250,7 @@ class Classic_SEO {
 		}
 		
 		if ( defined( 'WP_CLI' ) && WP_CLI && ! ( empty( $this->messages ) ) ) {
-			return \WP_CLI::error( implode( "\n", $this->messages ) );
+			return \WP_CLI::error( implode( "\n", $this->messages ), false );
 		}
 
 		// Auto-deactivate plugin.


### PR DESCRIPTION
Often the PHP version used for hosting a particular site is different from the one used by shell.

In this scenario, if you have PHP<7 used by WP-CLI, the command is not registered and you can't see it.

With this PR the command get registered but you will see an error.

Note that  `WP_CLI::error` by default exits (`exit(1)`).